### PR TITLE
serde::Formatter is now private, use std::Formatter instead

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -2,7 +2,7 @@ use actix_web::error::ResponseError;
 use actix_web::http::StatusCode;
 use actix_web::HttpResponse;
 use color_eyre::Report;
-use serde::export::Formatter;
+use core::fmt::Formatter;
 use serde::{Serialize, Serializer};
 use std::convert::From;
 use tracing::error;


### PR DESCRIPTION
See https://users.rust-lang.org/t/serde-compatibility-broken/54041. serde::Formatter is just a re-export of Rust's standard library's Formatter. Replacing this reference allows the repo to compile again.